### PR TITLE
Fix shell boolean OR logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,9 +73,9 @@ linting:
 
 	@echo "Running gofmt ..."
 
-	@test -z $(shell gofmt -l -e .) || echo "WARNING: gofmt linting errors found" \
+	@test -z $(shell gofmt -l -e .) || (echo "WARNING: gofmt linting errors found" \
 		&& gofmt -l -e -d . \
-		&& exit 1
+		&& exit 1 )
 
 	@echo "Running go vet ..."
 	@go vet ./...


### PR DESCRIPTION
The previous syntax resulted in false-positive problem reports from gofmt due to how the OR/AND logic was being applied. This commit wraps the intended OR logic in a set of parenthesis so the entire set of latter actions are executed together conditionally as intended.

refs #15