### PR TITLE
Process saved Page data as Markdown, render as HTML

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/atc0005/golang-writing-web-applications
+
+go 1.13
+
+require (
+	github.com/microcosm-cc/bluemonday v1.0.2
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	gopkg.in/russross/blackfriday.v2 v2.0.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/microcosm-cc/bluemonday v1.0.2 h1:5lPfLTTAvAbtS0VqT+94yOtFnGfUWYyx0+iToC3Os3s=
+github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
+github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+golang.org/x/net v0.0.0-20181220203305-927f97764cc3 h1:eH6Eip3UpmR+yM/qI9Ijluzb1bNv/cAU/n+6l8tRSis=
+golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+gopkg.in/russross/blackfriday.v2 v2.0.0 h1:+FlnIV8DSQnT7NZ43hcVKcdJdzZoeCmJj4Ql8gq5keA=
+gopkg.in/russross/blackfriday.v2 v2.0.0/go.mod h1:6sSBNz/GtOm/pJTuh5UmBK2ZHfmnxGbl2NZg1UliSOI=

--- a/main.go
+++ b/main.go
@@ -10,6 +10,9 @@ import (
 	"regexp"
 	"strings"
 	"text/template"
+
+	"github.com/microcosm-cc/bluemonday"
+	"gopkg.in/russross/blackfriday.v2"
 )
 
 // These directories reside in the same location as the running application
@@ -62,6 +65,8 @@ func frontPageHandler(w http.ResponseWriter, r *http.Request) {
 	return
 }
 
+// viewHandler performs any necessary conversion work between saved plain-text
+// (potentially Markdown) into HTML output.
 func viewHandler(w http.ResponseWriter, r *http.Request, title string) {
 
 	p, err := loadPage(title)
@@ -72,8 +77,16 @@ func viewHandler(w http.ResponseWriter, r *http.Request, title string) {
 		http.Redirect(w, r, "/edit/"+title, http.StatusFound)
 		return
 	}
-	// If the Page DOES exist, substitute any Page references to HTML links
+
+	// Since the Page exists perform conversion tasks on loaded data
+	processMarkdown(p)
+
+	// Intentionally perform inter-page linking after the Markdown to HTML
+	// conversion to reduce risk of improperly converting Markdown links to
+	// inter-page links.
 	createHTMLPageLinks(p)
+
+	// Send the results to the client
 	renderTemplate(w, "view", p)
 }
 
@@ -148,6 +161,25 @@ func createHTMLPageLinks(p *Page) {
 
 		return []byte(pageLink)
 	})
+
+}
+
+// processMarkdown runs a Markdown processor against the stored Page content
+// and replaces supported Markdown with HTML equivalents for display to
+// the client.
+func processMarkdown(p *Page) error {
+
+	// add protection against nil pointer deference
+	if p == nil {
+		return fmt.Errorf("aborting processing of nil pointer")
+	}
+
+	unsafe := blackfriday.Run(p.Body)
+	p.Body = bluemonday.UGCPolicy().SanitizeBytes(unsafe)
+
+	//	p.Body = blackfriday.Run(p.Body)
+
+	return nil
 
 }
 

--- a/tmpl/view.html
+++ b/tmpl/view.html
@@ -27,7 +27,9 @@
 
 <p>[<a href="/edit/{{.Title}}">edit</a>]</p>
 
-<div>{{printf "%s" .Body}}</div>
+<div>
+{{printf "%s" .Body}}
+</div>
 
 </body>
 </html>


### PR DESCRIPTION
- Use `microcosm-cc/bluemonday` package to sanitize potentially untrusted content

- Use `russross/blackfriday` package to process sanitized `Page` data as Markdown in order to render formatted HTML

fixes #10
